### PR TITLE
Add Ink Protocol (XNK)

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1,4 +1,11 @@
 {
+  "0xBC86727E770de68B1060C91f6BB6945c73e10388": {
+    "name": "Ink Protocol",
+    "logo": "ink_protocol.svg",
+    "erc20": true,
+    "symbol": "XNK",
+    "decimals": 18
+  },
   "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1": {
     "name": "PolySwarm Nectar",
     "logo": "polyswarm_nectar.svg",

--- a/images/ink_protocol.svg
+++ b/images/ink_protocol.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="1731.67px" height="1900px" viewBox="0 0 1731.67 1900" enable-background="new 0 0 1731.67 1900" xml:space="preserve">
+<g>
+	<path fill="#1E3C64" d="M895.836,9.512h-0.746v852.203c62.029,13,108.619,67.978,108.619,133.869
+		c0,20.144-4.473,39.223-12.304,56.453l733.72,333.503l-858.218,507.297l858.238-507.297L895.836,9.512z"/>
+	<path fill="#3C82B4" d="M8.669,1385.539l733.734-333.503c-7.831-17.23-12.298-36.31-12.298-56.453
+		c0-65.891,46.589-120.874,108.614-133.869V9.512h-0.741L8.669,1385.539z"/>
+	<path fill="#142846" d="M991.405,1052.036c-21.509,47.354-69.096,80.344-124.503,80.344l0.005,760.456l858.218-507.297
+		L991.405,1052.036z"/>
+	<path fill="#2D4B69" d="M866.897,1892.836L866.897,1892.836V1132.38c-55.393,0-102.989-32.989-124.494-80.344L8.669,1385.539
+		L866.897,1892.836z"/>
+</g>
+</svg>


### PR DESCRIPTION
Adding information for Ink Protocol (XNK):

- The icon should be small, square, but high resolution, ideally a vector/svg.
SVG image added to images directory, images/ink_protocol.svg

- Do not add your entry to the end of the JSON map, messing with the trailing comma. Your pull request should only be an addition of lines, and any line removals should be deliberate deprecations of those logos.
Added lines to beginning of JSON map

- PR should include link to official project website referencing the suggested address.
https://paywithink.com

- Project website should include explanation of project.
The website descibes the project. Here is a link to the whitepaper as well:
https://paywithink.com/#documents

- Project should have clear signs of activity, either traffic on the network, activity on GitHub, or community buzz.
https://etherscan.io/token/0xbc86727e770de68b1060c91f6bb6945c73e10388
https://twitter.com/PayWithInk
https://t.me/paywithink
http://medium.com/@paywithink

- Nice to have a verified source code on a block explorer like Etherscan.
https://etherscan.io/address/0xbc86727e770de68b1060c91f6bb6945c73e10388#code
