### PR TITLE
Updated token ENTR to ENTRP

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -58,7 +58,7 @@
   "0x5BC7e5f0Ab8b2E10D2D0a3F21739FCe62459aeF3": {
     "name": "Hut34 Entropy Token",
     "logo": "ENTRP.png",
-    "symbol": "ENTR",
+    "symbol": "ENTRP",
     "erc20": true,
     "decimals": 18
   },


### PR DESCRIPTION
Our ticker is ENTRP
I originally shortened this to suit the specs of the JSON.
The icon is not visible in metamask web extension for chrome.
Could this be why?