### PR TITLE
Update REP Token Address in Metamask

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -384,7 +384,7 @@
     "symbol": "PLU",
     "decimals": 18
   },
-  "0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6": {
+  "0x1985365e9f78359a9B6AD760e32412f4a445E862": {
     "name": "Reputation",
     "logo": "augur_logo.png",
     "erc20": true,


### PR DESCRIPTION
Project Website: https://augur.net

Explanation:
The July 9th Mainnet deploy of Augur comes with a new REP token address.

Here is a link on Etherscan:
https://etherscan.io/address/0x1985365e9f78359a9b6ad760e32412f4a445e862