### PR TITLE
Allow symbol five characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A sample submission:
 
 Tokens should include a field `"erc20": true`, and can include additional fields:
 
-- symbol (a four-character or less ticker symbol)
+- symbol (a five-character or less ticker symbol)
 - decimals (precision of the tokens stored)
 
 A full list of permitted fields can be found in the [permitted-fields.json](./permitted-fields.json) file.

--- a/contract-map.json
+++ b/contract-map.json
@@ -305,7 +305,7 @@
     "logo": "vslice.png",
     "erc20": true,
     "symbol": "VSL",
-    "decimals": 0
+    "decimals": 18
   },
   "0xFf3519eeeEA3e76F1F699CCcE5E23ee0bdDa41aC": {
     "name": "Blockchain Capital",

--- a/contract-map.json
+++ b/contract-map.json
@@ -304,7 +304,7 @@
     "name": "vSlice",
     "logo": "vslice.png",
     "erc20": true,
-    "symbol": "vSlice",
+    "symbol": "VSL",
     "decimals": 0
   },
   "0xFf3519eeeEA3e76F1F699CCcE5E23ee0bdDa41aC": {

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,17 @@ test('logos path names should not contain space', function (t) {
   t.end()
 })
 
+test('symbols should be five or less characters', function (t) {
+  Object.keys(contractMap).forEach(address => {
+    const contract = contractMap[address]
+    const symbol = contract.symbol
+    if (symbol) {
+      t.ok(symbol.length < 6, `symbol with more than 5 characters: "${symbol}"`)
+    }
+  })
+  t.end()
+})
+
 test('only permitted fields should be used', function (t) {
   Object.keys(contractMap).forEach(address => {
     const contract = contractMap[address]

--- a/test/index.js
+++ b/test/index.js
@@ -70,7 +70,7 @@ test('symbols should be five or less characters', function (t) {
     const contract = contractMap[address]
     const symbol = contract.symbol
     if (symbol) {
-      t.ok(symbol.length < 6, `symbol with more than 5 characters: "${symbol}"`)
+      t.notOk(symbol.length > 5, `symbol with more than 5 characters: "${symbol}"`)
     }
   })
   t.end()


### PR DESCRIPTION
Update `symbol` requirements to five characters or less.