### PR TITLE
Update contract-map.json

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -37,7 +37,7 @@
   "0x5BC7e5f0Ab8b2E10D2D0a3F21739FCe62459aeF3": {
     "name": "Hut34 Entropy Token",
     "logo": "ENTRP.png",
-    "symbol": "ENTR",
+    "symbol": "ENTRP",
     "erc20": true,
     "decimals": 18
   },


### PR DESCRIPTION
Hi guys!
I'm updating the ENTRP ticker to the correct one (ENTRP rather than ENTR)
I changed it to ENTR because it was not showing in the metamask wallet and suspected that the 5 digit ticker may be the cause -  in reality I just needed to wait for the next update to be pushed.

Thanks for your help.