### PR TITLE
Update to test to fix arbitrary symbol limit

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -70,7 +70,7 @@ test('symbols should be five or less characters', function (t) {
     const contract = contractMap[address]
     const symbol = contract.symbol
     if (symbol) {
-      t.notOk(symbol.length > 5, `symbol with more than 5 characters: "${symbol}"`)
+      t.notOk(symbol.length > 6, `symbol with more than 6 characters: "${symbol}"`)
     }
   })
   t.end()


### PR DESCRIPTION
the betaUI handles this very well already when reading in contract metadata on a manually added non-auto-detected token. the prior changes were added just 4 weeks ago and seem arbitrary and effect our efforts. the now default betaUI handles this well already.