### PR TITLE
test: fix discription, five -> six

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -65,7 +65,7 @@ test('logos path names should not contain space', function (t) {
   t.end()
 })
 
-test('symbols should be five or less characters', function (t) {
+test('symbols should be six or less characters', function (t) {
   Object.keys(contractMap).forEach(address => {
     const contract = contractMap[address]
     const symbol = contract.symbol


### PR DESCRIPTION
Test description for symbol length states 'symbols should be five or less characters' however tests for six. As there are a number of tokens with 6 character symbols the test itself seems correct. Description updated to reflect the test.