### PR TITLE
Remove ERC20 field from CryptoKitties

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A sample submission:
 }
 ```
 
-Tokens should include a field `"erc20": true`, and can include additional fields:
+ERC20 tokens should include a field `"erc20": true`, and can include additional fields:
 
 - symbol (a five-character or less ticker symbol)
 - decimals (precision of the tokens stored)

--- a/contract-map.json
+++ b/contract-map.json
@@ -261,9 +261,7 @@
   "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d": {
     "name": "Crypto Kitties",
     "logo": "CryptoKitties-Kitty-13733.svg",
-    "erc20": true,
-    "symbol": "CK",
-    "decimals": 0
+    "symbol": "CK"
   },
   "0xE477292f1B3268687A29376116B0ED27A9c76170": {
     "name": "Herocoin",


### PR DESCRIPTION
CryptoKitties is an ERC721 contract, not an ERC20 one.
This PR removes the ERC20-related fields from the cryptokitties entry so it won't be considered an ERC20 token.