### PR TITLE
Fix error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A sample submission:
 }
 ```
 
-Tokens should include a field `"erc20": true`, and can include additional fields:
+ERC20 tokens should include a field `"erc20": true`, and can include additional fields:
 
 - symbol (a five-character or less ticker symbol)
 - decimals (precision of the tokens stored)


### PR DESCRIPTION
Currently the readme states that all contracts should have `erc20:true` in their entries but only ERC20 tokens should use `erc20:true`. This PR fixes that.