### PR TITLE
Update TrueUSD address

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -898,8 +898,15 @@
     "symbol": "PAX",
     "decimals": 18
   },
-  "0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E": {
+  "0x0000000000085d4780B73119b644AE5ecd22b376": {
     "name": "TrueUSD",
+    "logo": "tusd.png",
+    "erc20": true,
+    "symbol": "TUSD",
+    "decimals": 18
+  },
+  "0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E": {
+    "name": "TrueUSD (Deprecated)",
     "logo": "tusd.png",
     "erc20": true,
     "symbol": "TUSD",


### PR DESCRIPTION
#### Changes
On January 3rd, TrueUSD exercised its [DelegateERC20](https://github.com/trusttoken/trueUSD/blob/master/contracts/DelegateERC20.sol) functionality.
The upgrade happened atomically [here](https://etherscan.io/tx/0x81c880de8f67362cb4792990560a6adf9aab819bbe28e334867ce8e4f88415a6).
The new contract address is **0x0000000000085d4780B73119b644AE5ecd22b376**.
Both addresses control the same tokens, but 0x0000000000085d4780B73119b644AE5ecd22b376 requires approximately 4800 less gas.
Therefore, we want to encourage use of the new address by marking the old address deprecated and listing the new address.
Reviewers @estebanmino