### PR TITLE
Add PLA token

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1334,6 +1334,13 @@
     "symbol": "DANK",
     "decimals": 18  
   },
+  "0x5f5b176553e51171826D1A62e540bC30422C7717": {
+    "name": "PLA Token",
+    "logo": "PLA.svg",
+    "erc20": true,
+    "symbol": "PLA",
+    "decimals": 18
+  },
   "0xE9e3F9cfc1A64DFca53614a0182CFAD56c10624F": {
     "name": "Su Squares",
     "logo": "Su-Squares.svg",

--- a/images/PLA.svg
+++ b/images/PLA.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100px" height="100px" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 56.3 (81716) - https://sketch.com -->
+    <title>Group 3@1.5x</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="10.7036868%" y1="8.78284213%" x2="83.706912%" y2="90.6271622%" id="linearGradient-1">
+            <stop stop-color="#07E595" offset="0%"></stop>
+            <stop stop-color="#00C7D3" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="51.0995941%" y1="11.9664778%" x2="51.0995941%" y2="50%" id="linearGradient-2">
+            <stop stop-color="#FFFFFF" stop-opacity="0.5" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="15.9064363%" y1="65.7977429%" x2="50%" y2="50%" id="linearGradient-3">
+            <stop stop-color="#FFFFFF" stop-opacity="0.5" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="50%" x2="85.6756631%" y2="65.6793693%" id="linearGradient-4">
+            <stop stop-color="#FFFFFF" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" stop-opacity="0.5" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group-3">
+            <rect id="Rectangle" fill="url(#linearGradient-1)" x="0" y="0" width="100" height="100"></rect>
+            <g id="Group" transform="translate(27.000000, 18.000000)">
+                <g id="Group-2">
+                    <path d="M-1.59872116e-14,57.4721612 L-1.59872116e-14,7.62401308 C-1.59872116e-14,3.49438345 3.34768519,0.146698265 7.47731481,0.146698265 C11.6069444,0.146698265 14.9546296,3.49438345 14.9546296,7.62401308 L14.9546296,57.4721612 C14.9546296,61.6013279 11.6069444,64.949476 7.47731481,64.949476 C3.34768519,64.949476 -1.59872116e-14,61.6013279 -1.59872116e-14,57.4721612 Z" id="Fill-4" fill="url(#linearGradient-2)"></path>
+                    <path d="M1.34583333,61.2892909 C-0.842592593,57.787439 0.222222222,53.174476 3.72407407,50.9855872 L43.6023148,26.0615131 C47.1037037,23.8730872 51.7171296,24.937439 53.9060185,28.4392909 C56.0949074,31.9411427 55.0300926,36.5541057 51.5282407,38.7429946 L11.649537,63.6670686 C10.4175926,64.436976 9.04722222,64.8045686 7.69351852,64.8045686 C5.20092593,64.8045686 2.76481481,63.5587353 1.34583333,61.2892909 Z" id="Fill-10" fill="url(#linearGradient-3)"></path>
+                    <path d="M43.6023148,38.7429946 L3.72407407,13.8189205 C0.222222222,11.6300316 -0.842592593,7.01706864 1.34583333,3.51521678 C3.53472222,0.0133649316 8.14768519,-1.05098692 11.649537,1.13743901 L51.5282407,26.0615131 C55.0300926,28.250402 56.0949074,32.8633649 53.9060185,36.3652168 C52.4875,38.6341983 50.0509259,39.8804946 47.5583333,39.8804946 C46.2046296,39.8804946 44.8347222,39.5133649 43.6023148,38.7429946 Z" id="Fill-7" fill="url(#linearGradient-4)"></path>
+                    <path d="M1.42108547e-14,64.8963911 L1.42108547e-14,42.3462353 C1.42108547e-14,38.2166057 3.34768519,34.8689205 7.47731481,34.8689205 C11.6069444,34.8689205 14.9546296,38.2166057 14.9546296,42.3462353 L14.9546296,64.8963911 L1.42108547e-14,64.8963911 Z" id="Fill-4" fill="#FFFFFF" transform="translate(7.477315, 49.882656) scale(1, -1) translate(-7.477315, -49.882656) "></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
PLA, the native token of PlayDapp, is a core utility token utilizing the ERC20 standard. PLA acts as the primary fungible token for the processing of transactions from users. Game dApp operators or developers receive PLA upon each in-game purchase or trade, after a reasonably small amount of transaction fee is deducted by PlayDapp

Website: https://playdapp.io
Official Site: https://cryptodozer.io/
Etherscan: https://etherscan.io/token/0x5f5b176553e51171826D1A62e540bC30422C7717
Twitter: https://twitter.com/playdapp_io
Medium: https://medium.com/playdapp
Facebook: https://www.facebook.com/groups/284269845572267