### PR TITLE
Added Enigma (enigma.co) to json map and added svg logo to images

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -6,6 +6,13 @@
     "symbol": "UPX",
     "decimals": 18
   },
+  "0xf0Ee6b27b759C9893Ce4f094b49ad28fd15A23e4": {
+    "name": "Enigma",
+    "logo": "enigma.svg",
+    "erc20": true,
+    "symbol": "ENG",
+    "decimals": 18
+  },
   "0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d": {
     "name": "Celsius",
     "logo": "celsius.svg",

--- a/images/enigma.svg
+++ b/images/enigma.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="400px" height="400px" viewBox="0 0 400 400" enable-background="new 0 0 400 400" xml:space="preserve">
+<g>
+	<polygon fill="#E72E9D" points="278.24,152.1 204.74,105.28 129.92,152.1 203.561,196.7 	"/>
+	<polygon fill="#20B1F9" points="205.221,282.359 279.66,243.26 281.859,156.06 204.62,198.88 	"/>
+	<polygon fill="#095198" points="203.561,285.32 200.54,197.94 125.34,154.48 122.34,240.52 	"/>
+	<polygon fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" points="358.6,110.2 203.859,20 46.32,108.38 
+		46.46,286.779 204.12,373.24 358.34,284.62 	"/>
+	<circle cx="203.16" cy="50.44" r="6.24"/>
+	<circle cx="203.16" cy="81.8" r="6.24"/>
+	<circle cx="77.36" cy="268.24" r="6.24"/>
+	<circle cx="103.76" cy="253.44" r="6.24"/>
+	<circle cx="328.36" cy="268.24" r="6.24"/>
+	<circle cx="302.061" cy="253.44" r="6.24"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="46.06" y1="107.4" x2="203.561" y2="196.7"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="360.2" y1="109" x2="203.561" y2="196.7"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="204.6" y1="373.92" x2="203.561" y2="196.7"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="283.561" y1="239.221" x2="203.561" y2="285.32"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="281.88" y1="152.86" x2="281.939" y2="241.58"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="202.439" y1="104.5" x2="281.88" y2="152.86"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="124.82" y1="152.06" x2="205.26" y2="104.32"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="124.82" y1="242.16" x2="124.82" y2="152.06"/>
+	<line fill="none" stroke="#000000" stroke-width="8" stroke-miterlimit="10" x1="203.561" y1="285.32" x2="123.6" y2="239.5"/>
+</g>
+</svg>


### PR DESCRIPTION
Requesting to add Enigma (ENG) to list of tokens. 
Website: enigma.co
Blog (with token contract address referenced: https://blog.enigma.co/enigma-tokens-are-live-77525d4ef82c)
github: https://github.com/enigmampc
etherscan link (with neutral reputation): https://etherscan.io/token/0xf0ee6b27b759c9893ce4f094b49ad28fd15a23e4