### PR TITLE
Add MCO

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1,5 +1,5 @@
 {
-  "0xb63b606ac810a52cca15e44bb630fd42d8d1d83d": {
+  "0xB63B606Ac810a52cCa15e44bB630fd42D8d1d83d": {
     "name": "MCO Token",
     "logo": "mco.svg",
     "erc20": true,

--- a/contract-map.json
+++ b/contract-map.json
@@ -1,4 +1,11 @@
 {
+  "0xb63b606ac810a52cca15e44bb630fd42d8d1d83d": {
+    "name": "MCO Token",
+    "logo": "mco.svg",
+    "erc20": true,
+    "symbol": "MCO",
+    "decimals": 8
+  },
   "0x5f778ec4B31a506c1Dfd8b06F131E9B451a61D39": {
     "name": "UPX Token",
     "logo": "UPX.svg",

--- a/images/mco.svg
+++ b/images/mco.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 200 200" style="enable-background:new 0 0 200 200;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:#FFFFFF;}
+</style>
+<g>
+	<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="99.7727" y1="199.5871" x2="99.7727" y2="-0.4129">
+		<stop  offset="0" style="stop-color:#223164"/>
+		<stop  offset="0.9704" style="stop-color:#08203D"/>
+	</linearGradient>
+	<rect x="-0.23" y="-0.41" class="st0" width="200" height="200"/>
+	<g>
+		<g>
+			<path class="st1" d="M99.78,22.35l-66.9,38.62v77.23l66.9,38.62l66.88-38.62V60.97L99.78,22.35z M160.79,134.82l-61.01,35.22
+				l-61.01-35.22V64.37l61.01-35.24l61.01,35.24V134.82z"/>
+		</g>
+		<g>
+			<polygon class="st1" points="125.99,55.69 73.43,55.69 67.34,82.49 132.33,82.49 			"/>
+			<polygon class="st1" points="82.75,119.37 82.75,101.57 67.19,91.67 49.56,104.77 73.58,146.53 83.18,146.53 94.52,135.97 
+				94.52,130.66 			"/>
+			<polygon class="st1" points="116.85,86.54 82.82,86.54 88.55,101.51 86.8,118.29 99.77,118.29 112.87,118.23 111.24,101.51 			
+				"/>
+			<polygon class="st1" points="132.42,91.55 117.03,101.57 117.03,119.37 105.26,130.66 105.26,135.97 116.61,146.41 
+				126.08,146.41 149.98,104.77 			"/>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Crypto.com conducted the MCO Token Sale in May-June 2017 and raised US$26.7 million.
MCO has a circulating supply of 15.8 million tokens and trades on 22 exchanges globally. MCO Token Utility has been enhanced significantly since launch.

Official website: https://crypto.com 
Etherscan: https://etherscan.io/token/0xb63b606ac810a52cca15e44bb630fd42d8d1d83d
GitHub: https://github.com/monacohq