### PR TITLE
Add Metronome (MET)

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1,4 +1,11 @@
 {
+  "0xa3d58c4E56fedCae3a7c43A725aeE9A71F0ece4e": {
+    "name": "Metronome",
+    "logo": "metronome.svg",
+    "erc20": true,
+    "symbol": "MET",
+    "decimals": 18
+  },
   "0x49d716DFe60b37379010A75329ae09428f17118d": {
     "name": "PoolTogether Dai",
     "logo": "pldai.svg",

--- a/images/metronome.svg
+++ b/images/metronome.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1000px"
+	 height="1000px" viewBox="0 0 1000 1000" style="enable-background:new 0 0 1000 1000;" xml:space="preserve">
+<style type="text/css">
+	.st0{font-family:'MyriadPro-Regular';}
+	.st1{font-size:12px;}
+	.st2{fill:#7E61F8;}
+	.st3{fill:#FFFFFF;}
+	.st4{fill:#323232;}
+	.st5{fill:#EDEDED;}
+</style>
+<g id="Layer_1">
+	<text transform="matrix(1 0 0 1 433 499)" class="st0 st1">CircleM_WhiteOnPurple</text>
+</g>
+<g id="Text">
+</g>
+<g id="Foreground">
+	<g>
+		<circle class="st2" cx="500" cy="500" r="500"/>
+		<path class="st3" d="M243.05,678.12c19.47,0,35.3-16.21,35.3-36.14V445.16c0.9-51.38,42.19-91.53,94-91.53
+			c51.3,0,91.48,40.16,91.52,91.44c0,0.03,0,0.06,0,0.09v196.83c0,0.24,0.08,0.47,0.08,0.7c0.4,19.27,16.71,35.43,36.04,35.43
+			c0.15,0,0.28-0.04,0.43-0.05c0.14,0,0.27,0.05,0.41,0.05c19.47,0,35.3-16.21,35.3-36.14V445.16c0.9-51.38,42.19-91.53,94-91.53
+			c51.33,0,91.53,40.21,91.53,91.53v196.83c0,19.59,16.54,36.14,36.12,36.14c19.25,0,36.14-16.88,36.14-36.14V445.16
+			c0-90.31-73.47-163.78-163.78-163.78c-51.64,0-98.61,24.69-129.37,62.43c-30.02-37.95-76.37-62.43-128.41-62.43
+			c-90.12,0-166.26,75-166.26,163.78v196.83C206.09,660.56,224.05,678.12,243.05,678.12z"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Add support for the Metronome (MET).

Website: https://metronome.io/
Telegram: https://t.me/metronometoken
Twitter: https://twitter.com/MET_Token
Etherscan: https://etherscan.io/address/0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e
GitHub: https://github.com/autonomoussoftware/metronome

**Description**: Metronome ("Metronome" or "MET") is  focused on making greater decentralization possible and delivering institutional-class endurance. Metronome is founded on three key design principles:

- Self-governance with no undue influence from founders after initial launch and public access — contract governance starts at launch.

- Reliability and predictability where issuance and supply are immutable

- Portability to enable maximum decentralization, even across different blockchains. The first 'chainhop' took place in summer 2019, between Ethereum and Ethereum Classic

Additionally, Metronome reportedly offers advanced payment features as programmable money.

- Mass pay: The ability to send MET to multiple addresses in a single transaction to save on transaction fees.

- Subscriptions: The ability to authorize a set amount of MET to move between two addresses on a recurring basis.