### PR TITLE
Updated EDU token contract address

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -574,11 +574,11 @@
     "symbol": "LUN",
     "decimals": 18
   },
-  "0x5b26C5D0772E5bbaC8b3182AE9a13f9BB2D03765": {
-    "name": "EDU Token",
+  "0xC741f06082AA47F93729070aD0dD95E223Bda091": {
+    "name": "LEDU Token",
     "logo": "edu.svg",
     "erc20": true,
-    "symbol": "EDU",
+    "symbol": "LEDU",
     "decimals": 8
   },
   "0x5c543e7AE0A1104f78406C340E9C64FD9fCE5170": {


### PR DESCRIPTION
Please accept update of the EDU token contract address.
The old smart contract will be locked and deprecated to pave way for the token swap. 
Details are in the official article: https://ledu.education-ecosystem.com/blog/new-ledu-coin-smart-contract-in-the-wake-of-the-to/