### PR TITLE
Update and modernize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ function imageElFor (address) {
   const metadata = contractMap[toChecksumAddress(address)]
   if (metadata?.logo) {
     const fileName = metadata.logo
-    const path = `images/contract/${fileName}`
+    const path = `${__dirname}/images/contract/${fileName}`
     const img = document.createElement('img')
     img.src = path
     img.style.width = '100%'

--- a/README.md
+++ b/README.md
@@ -13,21 +13,23 @@ This repository is effectively frozen. We recommend that developers of new token
 You can install from npm with `npm install eth-contract-metadata` and use it in your code like this:
 
 ```javascript
-const contractMap = require('eth-contract-metadata')
-const toChecksumAddress = require('ethereumjs-util').toChecksumAddress
+import contractMap from 'eth-contract-metadata'
+import ethJSUtil from 'ethereumjs-util'
+const { toChecksumAddress } = ethJSUtil
 
 function imageElFor (address) {
-  const metadata = iconMap[toChecksumAddress(address)]
-  if (!('logo' in metadata)) {
-    return false
+  const metadata = contractMap[toChecksumAddress(address)]
+  if (metadata?.logo) {
+    const fileName = metadata.logo
+    const path = `images/contract/${fileName}`
+    const img = document.createElement('img')
+    img.src = path
+    img.style.width = '100%'
+    return img
   }
-  const fileName = metadata.logo
-  const path = `images/contract/${fileName}`
-  const img = document.createElement('img')
-  img.src = path
-  img.style.width = '100%'
-  return img
 }
+
+imageElFor ("0x06012c8cf97BEaD5deAe237070F9587f8E7A266d")
 ```
 
 ## Submission Process


### PR DESCRIPTION
I was looking at the **Usage** example in the `README.md` last night and realised `contractMap` was defined but wasn't being used. instead we have `iconMap` which was used in a previous example and looks like it was meant to be renamed.

This updates things to get rid of the `ReferenceError`.

Additionally, I've taken the liberty of modernising the syntax slightly from what was en vogue 3 years ago. It now uses `imports` rather than common JS `require` along with destructuring assignment and optional chaining syntax.

most of this syntax works in modern tool chains as well as the latest version of node (which at the time of this PR is node 14).