### PR TITLE
Add upgraded ADX

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -133,11 +133,18 @@
     "decimals": 18
   },
   "0x4470BB87d77b963A013DB939BE332f927f2b992e": {
+    "name": "AdEx Legacy Token",
+    "logo": "adex.svg",
+    "erc20": true,
+    "symbol": "ADXL",
+    "decimals": 4
+  },
+  "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3": {
     "name": "AdEx Token",
     "logo": "adex.svg",
     "erc20": true,
     "symbol": "ADX",
-    "decimals": 4
+    "decimals": 18
   },
   "0x1966d718A565566e8E202792658D7b5Ff4ECe469": {
     "name": "nDEX",


### PR DESCRIPTION
Adds the upgraded ADX token and renames the previous ADX token to "ADX Legacy token"

Here's the official announcement: https://www.adex.network/blog/token-upgrade-defi-features/
And a follow up announcement containing the address: https://www.adex.network/blog/token-upgrade-progress/

And the contract, verified on etherscan: https://etherscan.io/address/0xade00c28244d5ce17d72e40330b1c318cd12b7c3#code