### PR TITLE
Update AERGO contract address due to Kucoin hack

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1151,7 +1151,7 @@
     "symbol": "ICX",
     "decimals": 18
   },
-  "0xAE31b85Bfe62747d0836B82608B4830361a3d37a": {
+  "0x91Af0fBB28ABA7E31403Cb457106Ce79397FD4E6": {
     "name": "Aergo",
     "logo": "Aergo.svg",
     "erc20": true,


### PR DESCRIPTION
Due to the recent Kucoin hack, [Aergo has migrated their AERGO ERC-20 token smart contract](https://medium.com/aergo/completion-of-aergo-smart-contract-migration-e10ba23bd578).

As you can see from that article, tokens have been reissued 1:1 via this new smart contract, and automatically distributed to the holders of the previous token, so this upgrade path is a) correct, b) safe (most users won't even notice), and c) necessary, as the old address is now considered obsolete.

I am submitting this change on the explicit request of the Aergo team leadership, as a follow-up to my previous PR #456 which submitted the original entry for the token.